### PR TITLE
Avoid redundant setViewState calls

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -107,17 +107,22 @@ export default class CurrentViewSettingsPlugin extends Plugin {
             this.app.vault.getConfig("livePreview");
 
       if (!this.settings.ignoreForceViewAll) {
-        let state = leaf.getViewState();
+        const beforeMode = typedState.state.mode;
+        const beforeSource = typedState.state.source;
 
-        if (state.state) {
-          if (view.getMode() !== defaultViewMode) {
-            state.state.mode = defaultViewMode;
+        const desiredMode = view.getMode() !== defaultViewMode ? defaultViewMode : beforeMode;
+        const desiredSource = !defaultEditingModeIsLivePreview;
+
+        const shouldUpdate =
+          desiredMode !== beforeMode || (desiredMode === "source" && desiredSource !== beforeSource);
+
+        if (shouldUpdate) {
+          typedState.state.mode = desiredMode;
+          if (desiredMode === "source") {
+            typedState.state.source = desiredSource;
           }
-
-          state.state.source = defaultEditingModeIsLivePreview ? false : true;
+          await leaf.setViewState(typedState);
         }
-
-        await leaf.setViewState(state);
 
         this.openedFiles = resetOpenedNotes(this.app);
       }
@@ -129,16 +134,24 @@ export default class CurrentViewSettingsPlugin extends Plugin {
       view: MarkdownView,
       leaf: WorkspaceLeaf
     ) => {
-      if (value === "reading") {
-        viewState.state.mode = "preview";
-        viewState.state.source = false;
-      } else if (value === "source") {
-        viewState.state.mode = "source";
-        viewState.state.source = true;
-      } else if (value === "live") {
-        viewState.state.mode = "source";
-        viewState.state.source = false;
+      const beforeMode = viewState.state.mode;
+      const beforeSource = viewState.state.source;
+
+      const desiredMode: MarkdownViewState["mode"] = value === "reading" ? "preview" : "source";
+      const desiredSource = value === "source";
+
+      const shouldUpdate =
+        desiredMode !== beforeMode || (desiredMode === "source" && desiredSource !== beforeSource);
+
+      if (!shouldUpdate) {
+        return;
       }
+
+      viewState.state.mode = desiredMode;
+      if (desiredMode === "source") {
+        viewState.state.source = desiredSource;
+      }
+
       await leaf.setViewState(viewState);
     };
 


### PR DESCRIPTION
## Summary
Skip calling `leaf.setViewState()` when the computed view mode is already applied for the active leaf. This avoids unnecessary tab header re-renders (e.g. custom tab icon resets) while keeping existing rule/frontmatter behavior.

## Changes
- Only call `setViewState` when the desired `{mode, source}` differs from the current state.
- When desired mode is **Reading** (`mode="preview"`), treat `state.source` (Live Preview vs Source) as irrelevant and do not update it.

## Repro
1. Configure rules/frontmatter that resolve to the same mode you are already in.
2. Switch between tabs/leaves.
3. Before: `setViewState` is called redundantly and can trigger icon (DOM) refresh/reset.
4. After: no-op when already in the desired mode.

## Validation
- `npm test`
- `npm run build`