### PR TITLE
Fix frontmatter key input losing focus on keystroke

### DIFF
--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -32,8 +32,9 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.customFrontmatterKey = value || "current view";
             await this.plugin.saveSettings();
-            this.display(); // Refresh to update dropdowns
           });
+        // Refresh dropdowns only after the user leaves the field, not on every keystroke
+        text.inputEl.addEventListener("blur", () => this.display());
       });
 
     new Setting(containerEl)


### PR DESCRIPTION
## Changes

- Remove `this.display()` call from onChange handler that was refreshing the entire settings tab on every keystroke
- Add blur event listener to only refresh dropdown elements when the user leaves the input field

## Impact

This prevents the frontmatter key input from losing focus while typing, improving the user experience when entering custom keys.