### PR TITLE
feat: add tag rules for automatic view mode by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Automatically applies the right view mode when opening notes based on your rules
 Configure view modes based on:
 - **📁 Folder paths** – All notes in `Templates/` open in Source mode
 - **🔍 File patterns** – Match files using RegEx (e.g., all daily notes)
+- **🏷️ Tag rules** – Match notes by Obsidian tags (e.g., all notes tagged `sent` open in Reading mode)
 - **📋 Frontmatter** – Per-note control with custom metadata field
 
 <p align="center">
@@ -85,9 +86,10 @@ When you open a note, Current View checks for view mode rules in this order:
 
 ```
 1. File Pattern Rules  →  Exact path match or RegEx pattern
-2. Folder Rules        →  Deepest matching folder wins
-3. Frontmatter         →  Per-note override
-4. Obsidian Default    →  Your global Obsidian setting
+2. Tag Rules           →  Any matching tag in frontmatter
+3. Folder Rules        →  Deepest matching folder wins
+4. Frontmatter         →  Per-note override
+5. Obsidian Default    →  Your global Obsidian setting
 ```
 
 <!-- TODO: Add diagram showing priority flow -->
@@ -100,6 +102,11 @@ When you open a note, Current View checks for view mode rules in this order:
 - You open `Templates/meeting-note.md`
 - The note has frontmatter: `current view: reading`
 - **Result:** Opens in **Reading mode** (frontmatter wins)
+
+**Example with tag rule:**
+- You have a tag rule: `sent` → Reading mode
+- You open a note with `tags: [sent]` in its frontmatter
+- **Result:** Opens in **Reading mode** (tag rule applies automatically)
 
 ---
 
@@ -140,6 +147,14 @@ Folder: Templates/
 Mode: source
 ```
 
+**📬 Published/sent notes:**
+```yaml
+# Notes tagged with 'sent' or 'published' open in Reading mode
+Tag: sent
+Mode: reading
+```
+Any note with `tags: [sent]` in its frontmatter will automatically open in Reading mode.
+
 <!-- TODO: Add screenshot of common configurations -->
 <!-- <p align="center">
   <img src="assets/use-cases.png" alt="Common use case configurations" width="600" />
@@ -177,6 +192,7 @@ Mode: source
 ### Rules Configuration
 
 - **Folder Rules**: Apply view mode to all notes in a folder (context menu locks write here)
+- **Tag Rules**: Apply view mode to notes that have a specific tag
 - **File Patterns**: RegEx patterns or exact file paths (context menu file locks write here)
 
 ---

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -1,0 +1,144 @@
+import { getFileTags, collectMatchedRules } from "../src/lib/rules";
+import { App, TFile } from "obsidian";
+import type { CurrentViewSettings } from "../src/config/settings";
+
+const key = "current view";
+
+const makeSettings = (
+  overrides: Partial<CurrentViewSettings> = {}
+): CurrentViewSettings => ({
+  debounceTimeout: 0,
+  customFrontmatterKey: key,
+  ignoreAlreadyOpen: false,
+  ignoreForceViewAll: false,
+  folderRules: [],
+  explicitFileRules: [],
+  filePatterns: [],
+  tagRules: [],
+  showExplorerIcons: false,
+  showLockNotifications: false,
+  ...overrides,
+});
+
+const makeApp = (tags: unknown): App => {
+  const app = new App();
+  app.metadataCache = {
+    getFileCache: () => ({ frontmatter: { tags } }),
+  };
+  return app;
+};
+
+describe("getFileTags", () => {
+  test("returns empty array when file is null", () => {
+    const app = new App();
+    expect(getFileTags(app, null)).toEqual([]);
+  });
+
+  test("returns empty array when no tags in frontmatter", () => {
+    const app = new App();
+    const file = new TFile("note.md");
+    expect(getFileTags(app, file)).toEqual([]);
+  });
+
+  test("handles tags as a string", () => {
+    const app = makeApp("sent");
+    const file = new TFile("note.md");
+    expect(getFileTags(app, file)).toEqual(["sent"]);
+  });
+
+  test("handles tags as an array", () => {
+    const app = makeApp(["sent", "published"]);
+    const file = new TFile("note.md");
+    expect(getFileTags(app, file)).toEqual(["sent", "published"]);
+  });
+
+  test("strips leading # from tags", () => {
+    const app = makeApp(["#sent", "#Published"]);
+    const file = new TFile("note.md");
+    expect(getFileTags(app, file)).toEqual(["sent", "published"]);
+  });
+
+  test("normalizes tags to lowercase", () => {
+    const app = makeApp(["Sent", "PUBLISHED"]);
+    const file = new TFile("note.md");
+    expect(getFileTags(app, file)).toEqual(["sent", "published"]);
+  });
+
+  test("ignores non-string tag entries", () => {
+    const app = makeApp(["sent", 42, null]);
+    const file = new TFile("note.md");
+    expect(getFileTags(app, file)).toEqual(["sent"]);
+  });
+});
+
+describe("collectMatchedRules – tag rules", () => {
+  test("matches when file has the tag", () => {
+    const app = makeApp(["sent"]);
+    const file = new TFile("archive/note.md");
+    const settings = makeSettings({
+      tagRules: [{ tag: "sent", mode: `${key}: reading` }],
+    });
+
+    const result = collectMatchedRules(app, settings, file, () => false);
+    expect(result).toEqual([`${key}: reading`]);
+  });
+
+  test("does not match when file lacks the tag", () => {
+    const app = makeApp(["draft"]);
+    const file = new TFile("note.md");
+    const settings = makeSettings({
+      tagRules: [{ tag: "sent", mode: `${key}: reading` }],
+    });
+
+    const result = collectMatchedRules(app, settings, file, () => false);
+    expect(result).toEqual([]);
+  });
+
+  test("normalizes # prefix in rule tag", () => {
+    const app = makeApp(["sent"]);
+    const file = new TFile("note.md");
+    const settings = makeSettings({
+      tagRules: [{ tag: "#sent", mode: `${key}: reading` }],
+    });
+
+    const result = collectMatchedRules(app, settings, file, () => false);
+    expect(result).toEqual([`${key}: reading`]);
+  });
+
+  test("skips tag rules with empty tag or mode", () => {
+    const app = makeApp(["sent"]);
+    const file = new TFile("note.md");
+    const settings = makeSettings({
+      tagRules: [{ tag: "", mode: `${key}: reading` }, { tag: "sent", mode: "" }],
+    });
+
+    const result = collectMatchedRules(app, settings, file, () => false);
+    expect(result).toEqual([]);
+  });
+
+  test("tag rule priority: file patterns override tag rules", () => {
+    const app = makeApp(["sent"]);
+    const file = new TFile("note.md");
+    const settings = makeSettings({
+      tagRules: [{ tag: "sent", mode: `${key}: reading` }],
+      filePatterns: [{ pattern: "note.md", mode: `${key}: source` }],
+    });
+
+    const result = collectMatchedRules(app, settings, file, () => false);
+    // file pattern is pushed last → last wins in resolveViewModeDecision
+    expect(result).toEqual([`${key}: reading`, `${key}: source`]);
+  });
+
+  test("tag rules override folder rules", () => {
+    const app = makeApp(["sent"]);
+    const file = new TFile("docs/note.md");
+    const settings = makeSettings({
+      folderRules: [{ path: "docs", mode: `${key}: live` }],
+      tagRules: [{ tag: "sent", mode: `${key}: reading` }],
+    });
+
+    const result = collectMatchedRules(app, settings, file, () => false);
+    // folder rule first, tag rule second → tag rule wins
+    expect(result).toEqual([`${key}: live`, `${key}: reading`]);
+  });
+});

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -2,6 +2,7 @@ import { App, TFolder } from "obsidian";
 
 export type PathRule = { path: string; mode: string };
 export type PatternRule = { pattern: string; mode: string };
+export type TagRule = { tag: string; mode: string };
 
 export interface CurrentViewSettings {
   debounceTimeout: number;
@@ -11,6 +12,7 @@ export interface CurrentViewSettings {
   folderRules: PathRule[];
   explicitFileRules: PathRule[]; // legacy; migrated into filePatterns
   filePatterns: PatternRule[];
+  tagRules: TagRule[];
   showExplorerIcons: boolean;
   showLockNotifications: boolean;
 }
@@ -23,6 +25,7 @@ export const DEFAULT_SETTINGS: CurrentViewSettings = {
   folderRules: [{ path: "", mode: "" }],
   explicitFileRules: [],
   filePatterns: [{ pattern: "", mode: "" }],
+  tagRules: [{ tag: "", mode: "" }],
   showExplorerIcons: true,
   showLockNotifications: true,
 };

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -3,6 +3,16 @@ import type { CurrentViewSettings } from "../config/settings";
 import { normalizePath, isPathWithin } from "../config/settings";
 import { TFile, App } from "obsidian";
 
+export const getFileTags = (app: App, file: TFile | null): string[] => {
+  const cache = file ? app.metadataCache.getFileCache(file) : null;
+  const raw = cache?.frontmatter?.["tags"];
+  if (!raw) return [];
+  const tags = Array.isArray(raw) ? raw : [raw];
+  return tags
+    .filter((t): t is string => typeof t === "string")
+    .map((t) => t.replace(/^#/, "").toLowerCase().trim());
+};
+
 export type ViewLockMode = "reading" | "source" | "live";
 
 export const collectMatchedRules = (
@@ -23,6 +33,16 @@ export const collectMatchedRules = (
 
   for (const { mode } of matchedFolders) {
     matchedRuleModes.push(mode);
+  }
+
+  // Tag rules
+  const fileTags = getFileTags(app, file);
+  for (const { tag, mode } of settings.tagRules) {
+    if (!tag || !mode) continue;
+    const normalizedTag = tag.replace(/^#/, "").toLowerCase().trim();
+    if (fileTags.includes(normalizedTag)) {
+      matchedRuleModes.push(mode);
+    }
   }
 
   // File patterns (exact path or basename regex)
@@ -69,6 +89,13 @@ export const resolveLockModeForPath = (
 
   const file = app.vault.getAbstractFileByPath(path);
   if (file instanceof TFile) {
+    const fileTags = getFileTags(app, file);
+    for (const { tag, mode } of settings.tagRules) {
+      if (!tag || !mode) continue;
+      const normalizedTag = tag.replace(/^#/, "").toLowerCase().trim();
+      if (fileTags.includes(normalizedTag)) return mode;
+    }
+
     const fmMode = resolveFrontmatterMode(app, file, settings.customFrontmatterKey);
     if (fmMode) return fmMode;
   }

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -182,6 +182,71 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
       div.appendChild(containerEl.lastChild as Node);
     });
 
+    // === Tag Rules ===
+    new Setting(containerEl).setName("Tag Rules").setHeading();
+
+    new Setting(containerEl)
+      .setDesc("Apply view mode to notes that have a specific tag. Tag rules override folder rules but can be overridden by file pattern rules.");
+
+    new Setting(containerEl)
+      .setName("Add tag rule")
+      .setDesc("Click to add a new tag rule")
+      .addButton((button) => {
+        button
+          .setTooltip("Add tag rule")
+          .setButtonText("+")
+          .setCta()
+          .onClick(async () => {
+            this.plugin.settings.tagRules.push({ tag: "", mode: "" });
+            await this.plugin.saveSettings();
+            this.display();
+          });
+      });
+
+    this.plugin.settings.tagRules.forEach((tagRule, index) => {
+      const div = containerEl.createEl("div");
+      div.addClass("force-view-mode-div");
+      div.addClass("force-view-mode-folder");
+
+      const s = new Setting(this.containerEl)
+        .addSearch((cb) => {
+          cb.setPlaceholder("Example: sent, published")
+            .setValue(tagRule.tag)
+            .onChange(async (value) => {
+              if (
+                value &&
+                this.plugin.settings.tagRules.some((e) => e.tag === value)
+              ) {
+                console.error("ForceViewMode: Tag rule already exists", value);
+                return;
+              }
+              this.plugin.settings.tagRules[index].tag = value;
+              await this.plugin.saveSettings();
+            });
+        })
+        .addDropdown((cb) => {
+          modes.forEach((mode) => {
+            cb.addOption(mode, mode);
+          });
+          cb.setValue(tagRule.mode || "default").onChange(async (value) => {
+            this.plugin.settings.tagRules[index].mode = value;
+            await this.plugin.saveSettings();
+          });
+        })
+        .addExtraButton((cb) => {
+          cb.setIcon("cross")
+            .setTooltip("Delete")
+            .onClick(async () => {
+              this.plugin.settings.tagRules.splice(index, 1);
+              await this.plugin.saveSettings();
+              this.display();
+            });
+        });
+
+      s.infoEl.remove();
+      div.appendChild(containerEl.lastChild as Node);
+    });
+
     // === File Pattern Rules ===
     new Setting(containerEl).setName("File Pattern Rules").setHeading();
     


### PR DESCRIPTION
## Summary

- Adds a new **Tag Rules** section in plugin settings (between Folder Rules and File Pattern Rules)
- Notes tagged with specific tags (e.g. `sent`, `published`) automatically open in the configured view mode
- Tag rules are reflected in file explorer lock icons, just like folder and file pattern rules
- Priority order: File Patterns > Tag Rules > Folder Rules > Frontmatter > Obsidian Default

## Details

- New `TagRule` type and `tagRules` setting field (with migration-safe default)
- `getFileTags()` helper normalizes frontmatter tags (handles string/array, strips `#`, lowercases)
- `resolveLockModeForPath()` extended to resolve tag rules for explorer icon display
- 13 new unit tests covering all tag matching scenarios

Closes #38