### PR TITLE
fix: improve lock icon contrast on active sidebar items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -24,3 +24,8 @@
 .nav-folder-title:hover .current-view-lock {
   opacity: 1;
 }
+
+.nav-file-title.is-active .current-view-lock svg,
+.nav-folder-title.is-active .current-view-lock svg {
+  color: var(--text-on-accent);
+}


### PR DESCRIPTION
## Summary

- Lock icon color on active sidebar items uses `var(--text-muted)`, which has poor contrast against the accent background and looks washed out.
- Add a CSS rule that switches the icon to `var(--text-on-accent)` when its parent nav item is active.

## Testing

- `npm test`: 20 passed
- `npm run build`: passed
- Manual: enable "Lock current view" on a note, select it in the file explorer, verify the lock icon contrasts cleanly against the accent background. Unselected items render as before.

### Before / After

**Before:**

![before](https://i.ibb.co/svMLcBZM/before.jpg)

**After:**

![after](https://i.ibb.co/cX7y6cGF/after.jpg)

## Checklist

- [x] Tests added/updated. CSS-only, covered by manual verification
- [x] Build passes locally
- [x] Docs/README updated if needed. Not applicable
- [x] No unrelated changes included
