### PR TITLE
fix: address plugin review lint warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 # Local tool state
 .claude/
 AGENTS.md
+REVIEW.md
 
 # Build output
 main.js

--- a/src/lib/view-mode.ts
+++ b/src/lib/view-mode.ts
@@ -21,7 +21,7 @@ export const parseRuleMode = (
   const [key, value] = rawMode.split(":").map((s) => s.trim());
   if (key === "default") return null;
   if (key !== customFrontmatterKey) return null;
-  return isValidMode(value) ? (value as ViewMode) : null;
+  return isValidMode(value) ? value : null;
 };
 
 export const resolveViewModeDecision = ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import {
   App,
   TFile,
   TFolder,
-  Setting,
   debounce,
   ViewState,
   Menu,
@@ -20,7 +19,7 @@ import {
 import { collectMatchedRules } from "./lib/rules";
 import { addLockMenuItems, decorateFileExplorer, clearDecorations, LockTarget } from "./ui/context-menu";
 import { initNotebookNavigatorIntegration, destroyNotebookNavigatorIntegration, decorateNotebookNavigator } from "./ui/notebook-navigator";
-import { normalizePath, isPathWithin } from "./config/settings";
+import { normalizePath } from "./config/settings";
 import { CurrentViewSettingsTab } from "./ui/settings-tab";
 
 type MarkdownViewState = {
@@ -30,7 +29,7 @@ type MarkdownViewState = {
 
 export default class CurrentViewSettingsPlugin extends Plugin {
   settings: CurrentViewSettings;
-  openedFiles: String[];
+  openedFiles: string[];
 
   async onload() {
     await this.loadSettings();
@@ -131,7 +130,7 @@ export default class CurrentViewSettingsPlugin extends Plugin {
     const applyViewMode = async (
       viewState: ViewState & { state: MarkdownViewState },
       value: string,
-      view: MarkdownView,
+      _view: MarkdownView,
       leaf: WorkspaceLeaf
     ) => {
       const beforeMode = viewState.state.mode;
@@ -221,7 +220,7 @@ export default class CurrentViewSettingsPlugin extends Plugin {
     await this.saveData(this.settings);
   }
 
-  async onunload() {
+  onunload() {
     clearDecorations();
     destroyNotebookNavigatorIntegration();
     resetViewsToDefault(this);
@@ -229,17 +228,17 @@ export default class CurrentViewSettingsPlugin extends Plugin {
   }
 }
 
-function alreadyOpen(currFile: TFile, openedFiles: String[]): boolean {
-  const leavesWithSameNote: String[] = [];
+function alreadyOpen(currFile: TFile, openedFiles: string[]): boolean {
+  const leavesWithSameNote: string[] = [];
   if (currFile == null) return false;
-  openedFiles.forEach((openedFile: String) => {
+  openedFiles.forEach((openedFile: string) => {
     if (openedFile == currFile.basename) leavesWithSameNote.push(openedFile);
   });
   return leavesWithSameNote.length != 0;
 }
 
-function resetOpenedNotes(app: App): String[] {
-  let openedFiles: String[] = [];
+function resetOpenedNotes(app: App): string[] {
+  let openedFiles: string[] = [];
   app.workspace.iterateAllLeaves((leaf) => {
     let view = leaf.view instanceof MarkdownView ? leaf.view : null;
     if (null === view) return;
@@ -255,7 +254,7 @@ function resetOpenedNotes(app: App): String[] {
 const resetViewsToDefault = (plugin: CurrentViewSettingsPlugin) => {
   const leaves = plugin.app.workspace.getLeavesOfType("markdown");
   leaves.forEach((leaf) => {
-    const view = leaf.view instanceof MarkdownView ? (leaf.view as MarkdownView) : null;
+    const view = leaf.view instanceof MarkdownView ? leaf.view : null;
     if (!view) return;
     const state = leaf.getViewState();
     if (!state.state) return;
@@ -273,6 +272,6 @@ const resetViewsToDefault = (plugin: CurrentViewSettingsPlugin) => {
           plugin.app.vault.getConfig("livePreview");
     state.state.mode = defaultViewMode;
     state.state.source = defaultEditingModeIsLivePreview ? false : true;
-    leaf.setViewState(state);
+    void leaf.setViewState(state);
   });
 };

--- a/src/ui/context-menu.ts
+++ b/src/ui/context-menu.ts
@@ -1,4 +1,4 @@
-import { Menu, Notice, TFolder, TFile, setIcon } from "obsidian";
+import { Menu, Notice, setIcon } from "obsidian";
 import type CurrentViewSettingsPlugin from "../main";
 import type { ViewLockMode } from "../lib/rules";
 import { normalizePath } from "../config/settings";
@@ -106,18 +106,8 @@ export const decorateFileExplorer = (plugin: CurrentViewSettingsPlugin) => {
       }
 
       if (mode) {
-        const badge: HTMLElement = existing || document.createElement("span");
-        badge.className = "current-view-lock";
+        const badge: HTMLElement = existing ?? createSpan({ cls: "current-view-lock" });
         badge.setAttribute("aria-label", `Locked ${mode}`);
-        badge.style.marginLeft = "6px";
-        badge.style.opacity = "0.8";
-        badge.style.display = "inline-flex";
-        badge.style.alignItems = "center";
-        badge.style.justifyContent = "center";
-        badge.style.width = "14px";
-        badge.style.height = "14px";
-        badge.style.verticalAlign = "middle";
-        badge.style.color = "var(--text-muted)";
         badge.innerHTML = "";
         setIcon(badge, renderModeIcon(mode));
         if (!existing) {
@@ -158,5 +148,5 @@ const renderModeIcon = (mode: string): string => {
 };
 
 export const clearDecorations = () => {
-  document.querySelectorAll(".current-view-lock").forEach((el) => el.remove());
+  activeDocument.querySelectorAll(".current-view-lock").forEach((el) => el.remove());
 };

--- a/src/ui/notebook-navigator.ts
+++ b/src/ui/notebook-navigator.ts
@@ -21,7 +21,7 @@ const VIEW_LOCKS: ViewLockMode[] = ["reading", "source", "live"];
 let fileListObserver: MutationObserver | null = null;
 let fileMenuDispose: MenuExtensionDispose | null = null;
 let folderMenuDispose: MenuExtensionDispose | null = null;
-let decorateDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+let decorateDebounceTimer: number | null = null;
 
 /**
  * Get the Notebook Navigator API if available
@@ -40,7 +40,7 @@ export const initNotebookNavigatorIntegration = (plugin: CurrentViewSettingsPlug
   tryRegisterMenus(plugin);
   
   // Also try again after a delay, in case Notebook Navigator loads after us
-  setTimeout(() => {
+  activeWindow.setTimeout(() => {
     if (!fileMenuDispose && !folderMenuDispose) {
       tryRegisterMenus(plugin);
     }
@@ -84,7 +84,7 @@ export const destroyNotebookNavigatorIntegration = () => {
 
   // Cleanup file list observer and pending debounce
   if (decorateDebounceTimer) {
-    clearTimeout(decorateDebounceTimer);
+    activeWindow.clearTimeout(decorateDebounceTimer);
     decorateDebounceTimer = null;
   }
   fileListObserver?.disconnect();
@@ -161,53 +161,19 @@ const extractPathFromElement = (el: HTMLElement): string | null => {
 };
 
 /**
- * Resolve a path (which might be just a filename) to a full vault path
- * (Still needed for icon decorations)
- */
-const resolvePathInVault = (
-  plugin: CurrentViewSettingsPlugin,
-  path: string,
-  type: LockTarget
-): string | null => {
-  // If it's already a valid path, return it
-  const abstractFile = plugin.app.vault.getAbstractFileByPath(path);
-  if (abstractFile) {
-    return abstractFile.path;
-  }
-
-  // Try to find file by name
-  if (type === "file") {
-    const files = plugin.app.vault.getFiles();
-    const match = files.find(
-      (f) => f.basename === path || f.name === path || f.path === path
-    );
-    if (match) return match.path;
-  }
-
-  // For folders, try common patterns
-  if (type === "folder") {
-    const folders = plugin.app.vault.getAllFolders();
-    const match = folders.find((f) => f.name === path || f.path === path);
-    if (match) return match.path;
-  }
-
-  return null;
-};
-
-/**
  * Watch for Notebook Navigator file list changes to add lock icons
  */
 const setupFileListObserver = (plugin: CurrentViewSettingsPlugin) => {
   fileListObserver = new MutationObserver(() => {
-    if (decorateDebounceTimer) clearTimeout(decorateDebounceTimer);
-    decorateDebounceTimer = setTimeout(() => {
+    if (decorateDebounceTimer) activeWindow.clearTimeout(decorateDebounceTimer);
+    decorateDebounceTimer = activeWindow.setTimeout(() => {
       decorateDebounceTimer = null;
       decorateNotebookNavigator(plugin);
     }, 150);
   });
 
   // Observe the entire document for nn-file elements
-  fileListObserver.observe(document.body, {
+  fileListObserver.observe(activeDocument.body, {
     childList: true,
     subtree: true,
   });
@@ -242,7 +208,7 @@ export const decorateNotebookNavigator = (plugin: CurrentViewSettingsPlugin) => 
   }
 
   // Decorate files in the file list
-  const fileItems = document.querySelectorAll(".nn-file");
+  const fileItems = activeDocument.querySelectorAll(".nn-file");
 
   fileItems.forEach((fileEl) => {
     const path = extractPathFromElement(fileEl as HTMLElement);
@@ -262,7 +228,7 @@ export const decorateNotebookNavigator = (plugin: CurrentViewSettingsPlugin) => 
   });
 
   // Decorate folders in the navigation pane
-  const folderItems = document.querySelectorAll(".nn-folder");
+  const folderItems = activeDocument.querySelectorAll(".nn-folder");
 
   folderItems.forEach((folderEl) => {
     const path = extractPathFromElement(folderEl as HTMLElement);
@@ -289,19 +255,8 @@ const addLockBadge = (titleEl: HTMLElement, mode: string | null) => {
   const existing = titleEl.querySelector(".current-view-lock-nn") as HTMLElement | null;
 
   if (mode) {
-    const badge: HTMLElement = existing || document.createElement("span");
-    badge.className = "current-view-lock-nn";
+    const badge: HTMLElement = existing ?? createSpan({ cls: "current-view-lock-nn" });
     badge.setAttribute("aria-label", `Locked ${mode}`);
-    badge.style.marginLeft = "4px";
-    badge.style.opacity = "0.7";
-    badge.style.display = "inline-flex";
-    badge.style.alignItems = "center";
-    badge.style.justifyContent = "center";
-    badge.style.width = "12px";
-    badge.style.height = "12px";
-    badge.style.verticalAlign = "middle";
-    badge.style.color = "var(--text-muted)";
-    badge.style.flexShrink = "0";
     badge.innerHTML = "";
     setIcon(badge, renderModeIcon(mode));
     if (!existing) {
@@ -326,5 +281,5 @@ const renderModeIcon = (mode: string): string => {
  * Remove all Notebook Navigator lock decorations
  */
 export const clearNotebookNavigatorDecorations = () => {
-  document.querySelectorAll(".current-view-lock-nn").forEach((el) => el.remove());
+  activeDocument.querySelectorAll(".current-view-lock-nn").forEach((el) => el.remove());
 };

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -19,9 +19,6 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
       cls: "setting-item-description"
     });
 
-    // === General Settings ===
-    new Setting(containerEl).setName("General").setHeading();
-
     new Setting(containerEl)
       .setName("Frontmatter key")
       .setDesc("Custom frontmatter field to define view mode per note.")
@@ -136,7 +133,7 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
       });
 
     this.plugin.settings.folderRules.forEach((folderMode, index) => {
-      const div = containerEl.createEl("div");
+      const div = containerEl.createDiv();
       div.addClass("force-view-mode-div");
       div.addClass("force-view-mode-folder");
 
@@ -204,7 +201,7 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
       });
 
     this.plugin.settings.tagRules.forEach((tagRule, index) => {
-      const div = containerEl.createEl("div");
+      const div = containerEl.createDiv();
       div.addClass("force-view-mode-div");
       div.addClass("force-view-mode-folder");
 
@@ -272,7 +269,7 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
       });
 
     this.plugin.settings.filePatterns.forEach((file, index) => {
-      const div = containerEl.createEl("div");
+      const div = containerEl.createDiv();
       div.addClass("force-view-mode-div");
       div.addClass("force-view-mode-folder");
 

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,33 @@
 /* Current View Plugin Styles */
 
-/* Lock Icons in File Explorer and Notebook Navigator */
+/* Lock Icons - shared styles */
 .current-view-lock,
 .current-view-lock-nn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-left: 4px;
-  opacity: 0.7;
   vertical-align: middle;
   flex-shrink: 0;
 }
 
-.current-view-lock svg,
+/* File Explorer badge */
+.current-view-lock {
+  margin-left: 6px;
+  opacity: 0.8;
+}
+
+.current-view-lock svg {
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+}
+
+/* Notebook Navigator badge */
+.current-view-lock-nn {
+  margin-left: 4px;
+  opacity: 0.7;
+}
+
 .current-view-lock-nn svg {
   width: 12px;
   height: 12px;


### PR DESCRIPTION
## Summary

- Remove unused imports (`Setting`, `isPathWithin`, `TFolder`, `TFile`) and unused function (`resolvePathInVault`)
- Replace `String` with `string` primitive type throughout
- Remove unnecessary type assertions (`as MarkdownView`, `as ViewMode`)
- Remove `async` from `onunload()` — no async operations, avoids Promise-returning-void override warning
- Add `void` to unhandled `setViewState` promise call
- Use `activeDocument` instead of `document` for popout window compatibility
- Use `activeWindow.setTimeout()` / `activeWindow.clearTimeout()` for popout window compatibility
- Use `createSpan()` instead of `document.createElement("span")`
- Use `containerEl.createDiv()` instead of `containerEl.createEl("div")`
- Remove `"General"` heading from settings tab (discouraged by Obsidian guidelines)
- Replace all inline `element.style.*` assignments with CSS classes; `styles.css` updated to correctly separate file-explorer (`.current-view-lock`) and notebook-navigator (`.current-view-lock-nn`) badge styles
- Add `REVIEW.md` to `.gitignore` so the local review file is never accidentally committed

## What's not addressed yet

- `any` type warnings in event handlers / file-explorer internals (unavoidable without Obsidian internal typings)
- `Vault.getAllFolders` / `setTooltip` `minAppVersion` mismatches (requires decision on bumping `minAppVersion`)
- `builtin-modules` replacement (needs research)
- `this: void` scoping warning in `notebook-navigator.ts`
- Release artifact issues (CHANGELOG in release, missing artifact attestations) — CI/workflow changes
- Dependency vulnerability warnings (all in dev-only transitive deps)
- README placeholder text