### PR TITLE
Fix frontmatter-Priorität vor Folder- und File-Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@
   </a>
 </p>
 
-<!-- TODO: Add hero image/demo GIF here -->
-<!-- <p align="center">
-  <img src="assets/demo-hero.gif" alt="Current View Demo" width="800" />
-</p> -->
-
 ---
 
 ## ✨ Features
@@ -85,17 +80,12 @@ Full support for [Notebook Navigator](https://github.com/johansan/notebook-navig
 When you open a note, Current View checks for view mode rules in this order:
 
 ```
-1. File Pattern Rules  →  Exact path match or RegEx pattern
-2. Tag Rules           →  Any matching tag in frontmatter
-3. Folder Rules        →  Deepest matching folder wins
-4. Frontmatter         →  Per-note override
+1. Frontmatter         →  Per-note override
+2. File Pattern Rules  →  Exact path match or RegEx pattern
+3. Tag Rules           →  Any matching tag in frontmatter
+4. Folder Rules        →  Deepest matching folder wins
 5. Obsidian Default    →  Your global Obsidian setting
 ```
-
-<!-- TODO: Add diagram showing priority flow -->
-<!-- <p align="center">
-  <img src="assets/priority-diagram.png" alt="View mode priority diagram" width="500" />
-</p> -->
 
 **Example:**
 - You have a folder rule: `Templates/` → Source mode
@@ -154,11 +144,6 @@ Tag: sent
 Mode: reading
 ```
 Any note with `tags: [sent]` in its frontmatter will automatically open in Reading mode.
-
-<!-- TODO: Add screenshot of common configurations -->
-<!-- <p align="center">
-  <img src="assets/use-cases.png" alt="Common use case configurations" width="600" />
-</p> -->
 
 ---
 

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -1,4 +1,4 @@
-import { getFileTags, collectMatchedRules } from "../src/lib/rules";
+import { getFileTags, collectMatchedRules, resolveLockModeForPath } from "../src/lib/rules";
 import { App, TFile } from "obsidian";
 import type { CurrentViewSettings } from "../src/config/settings";
 
@@ -20,10 +20,15 @@ const makeSettings = (
   ...overrides,
 });
 
-const makeApp = (tags: unknown): App => {
+const makeApp = (frontmatterOrTags: Record<string, unknown> | unknown): App => {
   const app = new App();
+  const frontmatter =
+    frontmatterOrTags && typeof frontmatterOrTags === "object" && !Array.isArray(frontmatterOrTags)
+      ? (frontmatterOrTags as Record<string, unknown>)
+      : { tags: frontmatterOrTags };
+
   app.metadataCache = {
-    getFileCache: () => ({ frontmatter: { tags } }),
+    getFileCache: () => ({ frontmatter }),
   };
   return app;
 };
@@ -140,5 +145,20 @@ describe("collectMatchedRules – tag rules", () => {
     const result = collectMatchedRules(app, settings, file, () => false);
     // folder rule first, tag rule second → tag rule wins
     expect(result).toEqual([`${key}: live`, `${key}: reading`]);
+  });
+});
+
+describe("resolveLockModeForPath", () => {
+  test("frontmatter overrides file, tag, and folder rules for files", () => {
+    const file = new TFile("templates/index.md");
+    const app = makeApp({ [key]: "reading", tags: ["template"] });
+    app.vault.getAbstractFileByPath = () => file;
+    const settings = makeSettings({
+      folderRules: [{ path: "templates", mode: `${key}: source` }],
+      tagRules: [{ tag: "template", mode: `${key}: live` }],
+      filePatterns: [{ pattern: "templates/index.md", mode: `${key}: source` }],
+    });
+
+    expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: reading`);
   });
 });

--- a/__tests__/view-mode.spec.ts
+++ b/__tests__/view-mode.spec.ts
@@ -14,7 +14,7 @@ describe("resolveViewModeDecision", () => {
     expect(result).toEqual({ mode: "live", source: "rule" });
   });
 
-  test("falls back to frontmatter when no rule applies", () => {
+  test("uses frontmatter when no rule applies", () => {
     const result = resolveViewModeDecision({
       matchedRuleModes: [],
       frontmatterValue: "source",
@@ -22,6 +22,16 @@ describe("resolveViewModeDecision", () => {
     });
 
     expect(result).toEqual({ mode: "source", source: "frontmatter" });
+  });
+
+  test("frontmatter overrides matching rules", () => {
+    const result = resolveViewModeDecision({
+      matchedRuleModes: [`${key}: source`, `${key}: live`],
+      frontmatterValue: "reading",
+      customFrontmatterKey: key,
+    });
+
+    expect(result).toEqual({ mode: "reading", source: "frontmatter" });
   });
 
   test("default rule clears previous matches and defers to frontmatter", () => {

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -76,18 +76,18 @@ export const resolveLockModeForPath = (
   path: string
 ): string | null => {
   const normalizedPath = normalizePath(path);
+  const file = app.vault.getAbstractFileByPath(path);
+
+  if (file instanceof TFile) {
+    const fmMode = resolveFrontmatterMode(app, file, settings.customFrontmatterKey);
+    if (fmMode) return fmMode;
+  }
+
   const fileRule = settings.filePatterns.find(
     (r) => normalizePath(r.pattern) === normalizedPath && r.mode
   );
   if (fileRule) return fileRule.mode;
 
-  const folderRule = settings.folderRules
-    .filter((r) => r.path && r.mode && isPathWithin(normalizedPath, r.path))
-    .sort((a, b) => a.path.length - b.path.length)
-    .pop();
-  if (folderRule) return folderRule.mode;
-
-  const file = app.vault.getAbstractFileByPath(path);
   if (file instanceof TFile) {
     const fileTags = getFileTags(app, file);
     for (const { tag, mode } of settings.tagRules) {
@@ -95,10 +95,13 @@ export const resolveLockModeForPath = (
       const normalizedTag = tag.replace(/^#/, "").toLowerCase().trim();
       if (fileTags.includes(normalizedTag)) return mode;
     }
-
-    const fmMode = resolveFrontmatterMode(app, file, settings.customFrontmatterKey);
-    if (fmMode) return fmMode;
   }
+
+  const folderRule = settings.folderRules
+    .filter((r) => r.path && r.mode && isPathWithin(normalizedPath, r.path))
+    .sort((a, b) => a.path.length - b.path.length)
+    .pop();
+  if (folderRule) return folderRule.mode;
 
   return null;
 };

--- a/src/lib/view-mode.ts
+++ b/src/lib/view-mode.ts
@@ -33,6 +33,11 @@ export const resolveViewModeDecision = ({
   frontmatterValue: unknown;
   customFrontmatterKey: string;
 }): { mode: ViewMode | null; source: ModeSource | null } => {
+  const normalizedFrontmatter = normalizeFrontmatterMode(frontmatterValue);
+  if (normalizedFrontmatter) {
+    return { mode: normalizedFrontmatter, source: "frontmatter" };
+  }
+
   let resolvedMode: ViewMode | null = null;
   let source: ModeSource | null = null;
 
@@ -52,11 +57,6 @@ export const resolveViewModeDecision = ({
 
   if (resolvedMode) {
     return { mode: resolvedMode, source };
-  }
-
-  const normalizedFrontmatter = normalizeFrontmatterMode(frontmatterValue);
-  if (normalizedFrontmatter) {
-    return { mode: normalizedFrontmatter, source: "frontmatter" };
   }
 
   return { mode: null, source: null };

--- a/src/ui/context-menu.ts
+++ b/src/ui/context-menu.ts
@@ -97,7 +97,7 @@ export const decorateFileExplorer = (plugin: CurrentViewSettingsPlugin) => {
     Object.entries(items).forEach(([path, item]) => {
       const targetEl = getTitleElement(item);
       if (!targetEl) return;
-      const existing = targetEl.querySelector(".current-view-lock") as HTMLElement | null;
+      const existing = targetEl.querySelector<HTMLElement>(".current-view-lock");
       const mode = resolveLockModeForPath(plugin.app, plugin.settings, path);
 
       if (!plugin.settings.showExplorerIcons) {

--- a/src/ui/notebook-navigator.ts
+++ b/src/ui/notebook-navigator.ts
@@ -58,7 +58,7 @@ const tryRegisterMenus = (plugin: CurrentViewSettingsPlugin) => {
   
   if (api?.menus) {
     // Register menu items using the official API
-    fileMenuDispose = api.menus.registerFileMenu(({ addItem, file, selection }) => {
+    fileMenuDispose = api.menus.registerFileMenu(function (this: void, { addItem, file, selection }) {
       if (selection.mode !== 'single') {
         return; // Only show menu for single file selection
       }
@@ -66,7 +66,7 @@ const tryRegisterMenus = (plugin: CurrentViewSettingsPlugin) => {
       addLockMenuItemsToNotebookNavigator(addItem, file.path, "file", plugin);
     });
 
-    folderMenuDispose = api.menus.registerFolderMenu(({ addItem, folder }) => {
+    folderMenuDispose = api.menus.registerFolderMenu(function (this: void, { addItem, folder }) {
       addLockMenuItemsToNotebookNavigator(addItem, folder.path, "folder", plugin);
     });
   }
@@ -252,7 +252,7 @@ export const decorateNotebookNavigator = (plugin: CurrentViewSettingsPlugin) => 
  * Add or update lock badge on a title element
  */
 const addLockBadge = (titleEl: HTMLElement, mode: string | null) => {
-  const existing = titleEl.querySelector(".current-view-lock-nn") as HTMLElement | null;
+  const existing = titleEl.querySelector<HTMLElement>(".current-view-lock-nn");
 
   if (mode) {
     const badge: HTMLElement = existing ?? createSpan({ cls: "current-view-lock-nn" });


### PR DESCRIPTION
## Summary
- Frontmatter erhält jetzt die höchste Priorität bei der View-Mode-Auflösung
- Rule-Auflösung für Datei-Locks und UI-Badges wurde an dieselbe Reihenfolge angepasst
- README und Tests wurden an das korrigierte Verhalten angepasst
- Kleine Review-Quick-Wins wurden mit aufgenommen: entfernte README-Placeholder, explizite `this: void`-Callbacks, bereinigte `querySelector`-Assertions

Fixes #54
Addresses #49, #52, and #53

## Testing
- Neue und angepasste Unit-Tests für Frontmatter-Override und Lock-Priorität ergänzt
- `npm test` grün
- `npm run build` grün