### PR TITLE
feat: configurable view mode icons & frontmatter change detection

### DIFF
--- a/__tests__/icons.spec.ts
+++ b/__tests__/icons.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { getModeIcon, VIEW_MODE_ICON_DEFAULTS } from "../src/lib/icons";
+
+const defaults = {
+  iconReading: VIEW_MODE_ICON_DEFAULTS.reading,
+  iconLive: VIEW_MODE_ICON_DEFAULTS.live,
+  iconSource: VIEW_MODE_ICON_DEFAULTS.source,
+};
+
+const custom = {
+  iconReading: "eye",
+  iconLive: "pencil",
+  iconSource: "terminal",
+};
+
+describe("getModeIcon", () => {
+  it("returns reading icon for reading mode", () => {
+    expect(getModeIcon("reading", defaults)).toBe("book-open");
+    expect(getModeIcon("current view: reading", defaults)).toBe("book-open");
+  });
+
+  it("returns live icon for live mode", () => {
+    expect(getModeIcon("live", defaults)).toBe("pen-tool");
+    expect(getModeIcon("current view: live", defaults)).toBe("pen-tool");
+  });
+
+  it("returns source icon for source mode", () => {
+    expect(getModeIcon("source", defaults)).toBe("code");
+    expect(getModeIcon("current view: source", defaults)).toBe("code");
+  });
+
+  it("returns lock for unknown mode", () => {
+    expect(getModeIcon("unknown", defaults)).toBe("lock");
+    expect(getModeIcon("", defaults)).toBe("lock");
+  });
+
+  it("uses custom icons from settings", () => {
+    expect(getModeIcon("reading", custom)).toBe("eye");
+    expect(getModeIcon("live", custom)).toBe("pencil");
+    expect(getModeIcon("source", custom)).toBe("terminal");
+  });
+});

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -15,6 +15,9 @@ export interface CurrentViewSettings {
   tagRules: TagRule[];
   showExplorerIcons: boolean;
   showLockNotifications: boolean;
+  iconReading: string;
+  iconLive: string;
+  iconSource: string;
 }
 
 export const DEFAULT_SETTINGS: CurrentViewSettings = {
@@ -28,6 +31,9 @@ export const DEFAULT_SETTINGS: CurrentViewSettings = {
   tagRules: [{ tag: "", mode: "" }],
   showExplorerIcons: true,
   showLockNotifications: true,
+  iconReading: "book-open",
+  iconLive: "pen-tool",
+  iconSource: "code",
 };
 
 export const normalizePath = (path: string): string => {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -18,6 +18,7 @@ export interface CurrentViewSettings {
   iconReading: string;
   iconLive: string;
   iconSource: string;
+  frontmatterChangeReload: "off" | "notify" | "auto";
 }
 
 export const DEFAULT_SETTINGS: CurrentViewSettings = {
@@ -34,6 +35,7 @@ export const DEFAULT_SETTINGS: CurrentViewSettings = {
   iconReading: "book-open",
   iconLive: "pen-tool",
   iconSource: "code",
+  frontmatterChangeReload: "notify",
 };
 
 export const normalizePath = (path: string): string => {

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,0 +1,17 @@
+import type { CurrentViewSettings } from "../config/settings";
+
+export const VIEW_MODE_ICON_DEFAULTS = {
+  reading: "book-open",
+  live: "pen-tool",
+  source: "code",
+} as const;
+
+export const getModeIcon = (
+  mode: string,
+  settings: Pick<CurrentViewSettings, "iconReading" | "iconLive" | "iconSource">
+): string => {
+  if (mode.includes("reading")) return settings.iconReading;
+  if (mode.includes("live")) return settings.iconLive;
+  if (mode.includes("source")) return settings.iconSource;
+  return "lock";
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   debounce,
   ViewState,
   Menu,
+  Notice,
 } from "obsidian";
 import { resolveViewModeDecision } from "./lib/view-mode";
 import {
@@ -160,6 +161,66 @@ export default class CurrentViewSettingsPlugin extends Plugin {
         this.settings.debounceTimeout === 0
           ? readViewModeFromFrontmatterAndToggle
           : debounce(readViewModeFromFrontmatterAndToggle, this.settings.debounceTimeout)
+      )
+    );
+
+    this.registerEvent(
+      this.app.metadataCache.on(
+        "changed",
+        debounce((file: TFile) => {
+          if (this.settings.frontmatterChangeReload === "off") return;
+
+          const leaf = this.app.workspace.activeLeaf;
+          if (!leaf) return;
+          const view = leaf.view instanceof MarkdownView ? leaf.view : null;
+          if (!view || view.file?.path !== file.path) return;
+
+          const fileCache = this.app.metadataCache.getFileCache(file);
+          const newFrontmatterValue =
+            fileCache?.frontmatter?.[this.settings.customFrontmatterKey] ?? null;
+
+          const { mode: resolvedMode } = resolveViewModeDecision({
+            matchedRuleModes: collectMatchedRules(
+              this.app,
+              this.settings,
+              file,
+              (pattern) => file.basename.match(pattern) !== null
+            ),
+            frontmatterValue: newFrontmatterValue,
+            customFrontmatterKey: this.settings.customFrontmatterKey,
+          });
+
+          if (!resolvedMode) return;
+
+          const rawState = leaf.getViewState() as ViewState & { state: MarkdownViewState };
+          const desiredLeafMode = resolvedMode === "reading" ? "preview" : "source";
+          const desiredSource = resolvedMode === "source";
+          const alreadyCorrect =
+            rawState.state?.mode === desiredLeafMode &&
+            (desiredLeafMode === "preview" || rawState.state?.source === desiredSource);
+          if (alreadyCorrect) return;
+
+          if (this.settings.frontmatterChangeReload === "auto") {
+            void readViewModeFromFrontmatterAndToggle(leaf);
+          } else {
+            const modeLabel =
+              resolvedMode === "reading"
+                ? "Reading"
+                : resolvedMode === "live"
+                ? "Live Preview"
+                : "Source";
+            const frag = document.createDocumentFragment();
+            frag.createEl("span", {
+              text: `Current View: view mode changed to ${modeLabel}. `,
+            });
+            const btn = frag.createEl("button", { text: "Apply now" });
+            const notice = new Notice(frag, 8000);
+            btn.addEventListener("click", () => {
+              notice.hide();
+              void readViewModeFromFrontmatterAndToggle(leaf);
+            });
+          }
+        }, 500)
       )
     );
 

--- a/src/ui/context-menu.ts
+++ b/src/ui/context-menu.ts
@@ -3,6 +3,7 @@ import type CurrentViewSettingsPlugin from "../main";
 import type { ViewLockMode } from "../lib/rules";
 import { normalizePath } from "../config/settings";
 import { resolveLockModeForPath } from "../lib/rules";
+import { getModeIcon } from "../lib/icons";
 
 export type LockTarget = "file" | "folder";
 
@@ -109,7 +110,7 @@ export const decorateFileExplorer = (plugin: CurrentViewSettingsPlugin) => {
         const badge: HTMLElement = existing ?? createSpan({ cls: "current-view-lock" });
         badge.setAttribute("aria-label", `Locked ${mode}`);
         badge.innerHTML = "";
-        setIcon(badge, renderModeIcon(mode));
+        setIcon(badge, getModeIcon(mode, plugin.settings));
         if (!existing) {
           targetEl.appendChild(badge);
         }
@@ -132,20 +133,6 @@ const getTitleElement = (item: any): HTMLElement | null => {
   return candidates.find((el) => !!el) || null;
 };
 
-const renderModeBadge = (mode: string): string => {
-  if (mode.includes("reading")) return "reading";
-  if (mode.includes("live")) return "live";
-  if (mode.includes("source")) return "source";
-  return "unknown";
-};
-
-const renderModeIcon = (mode: string): string => {
-  const normalized = renderModeBadge(mode);
-  if (normalized === "reading") return "book-open";
-  if (normalized === "live") return "pen-tool";
-  if (normalized === "source") return "code";
-  return "lock";
-};
 
 export const clearDecorations = () => {
   activeDocument.querySelectorAll(".current-view-lock").forEach((el) => el.remove());

--- a/src/ui/notebook-navigator.ts
+++ b/src/ui/notebook-navigator.ts
@@ -15,6 +15,7 @@ import type { ViewLockMode } from "../lib/rules";
 import { resolveLockModeForPath } from "../lib/rules";
 import { setLock, removeLock, LockTarget } from "./context-menu";
 import type { NotebookNavigatorAPI, MenuExtensionDispose } from "../types/notebook-navigator";
+import { getModeIcon } from "../lib/icons";
 
 const VIEW_LOCKS: ViewLockMode[] = ["reading", "source", "live"];
 
@@ -224,7 +225,7 @@ export const decorateNotebookNavigator = (plugin: CurrentViewSettingsPlugin) => 
     if (!titleEl) return;
 
     // Always call addLockBadge - it will remove the badge if mode is null
-    addLockBadge(titleEl, mode);
+    addLockBadge(titleEl, mode, plugin);
   });
 
   // Decorate folders in the navigation pane
@@ -244,37 +245,27 @@ export const decorateNotebookNavigator = (plugin: CurrentViewSettingsPlugin) => 
     if (!titleEl) return;
 
     // Always call addLockBadge - it will remove the badge if mode is null
-    addLockBadge(titleEl, mode);
+    addLockBadge(titleEl, mode, plugin);
   });
 };
 
 /**
  * Add or update lock badge on a title element
  */
-const addLockBadge = (titleEl: HTMLElement, mode: string | null) => {
+const addLockBadge = (titleEl: HTMLElement, mode: string | null, plugin: CurrentViewSettingsPlugin) => {
   const existing = titleEl.querySelector<HTMLElement>(".current-view-lock-nn");
 
   if (mode) {
     const badge: HTMLElement = existing ?? createSpan({ cls: "current-view-lock-nn" });
     badge.setAttribute("aria-label", `Locked ${mode}`);
     badge.innerHTML = "";
-    setIcon(badge, renderModeIcon(mode));
+    setIcon(badge, getModeIcon(mode, plugin.settings));
     if (!existing) {
       titleEl.appendChild(badge);
     }
   } else if (existing) {
     existing.remove();
   }
-};
-
-/**
- * Get the appropriate icon for a lock mode
- */
-const renderModeIcon = (mode: string): string => {
-  if (mode.includes("reading")) return "book-open";
-  if (mode.includes("live")) return "pen-tool";
-  if (mode.includes("source")) return "code";
-  return "lock";
 };
 
 /**

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -104,6 +104,21 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
           });
       });
 
+    new Setting(containerEl)
+      .setName("Frontmatter change detection")
+      .setDesc(
+        "When the frontmatter view mode key of the active note changes, react without requiring a file switch."
+      )
+      .addDropdown((dd) => {
+        dd.addOption("off", "Off");
+        dd.addOption("notify", "Show notification with Apply button");
+        dd.addOption("auto", "Apply automatically");
+        dd.setValue(this.plugin.settings.frontmatterChangeReload).onChange(async (value) => {
+          this.plugin.settings.frontmatterChangeReload = value as "off" | "notify" | "auto";
+          await this.plugin.saveSettings();
+        });
+      });
+
     // === View Mode Icons ===
     new Setting(containerEl).setName("View Mode Icons").setHeading();
 

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,5 +1,8 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab, Setting, setIcon } from "obsidian";
 import type CurrentViewSettingsPlugin from "../main";
+import { VIEW_MODE_ICON_DEFAULTS } from "../lib/icons";
+import { decorateFileExplorer } from "./context-menu";
+import { decorateNotebookNavigator } from "./notebook-navigator";
 
 export class CurrentViewSettingsTab extends PluginSettingTab {
   plugin: CurrentViewSettingsPlugin;
@@ -100,6 +103,20 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           });
       });
+
+    // === View Mode Icons ===
+    new Setting(containerEl).setName("View Mode Icons").setHeading();
+
+    new Setting(containerEl)
+      .setDesc(createFragment((frag) => {
+        frag.appendText("Icon name from the Lucide icon set (up to v0.446.0). Browse available icons at ");
+        frag.createEl("a", { text: "lucide.dev", href: "https://lucide.dev" });
+        frag.appendText(".");
+      }));
+
+    this.addIconPickerSetting(containerEl, "Reading mode", "iconReading", VIEW_MODE_ICON_DEFAULTS.reading);
+    this.addIconPickerSetting(containerEl, "Live Preview mode", "iconLive", VIEW_MODE_ICON_DEFAULTS.live);
+    this.addIconPickerSetting(containerEl, "Source mode", "iconSource", VIEW_MODE_ICON_DEFAULTS.source);
 
     const modes = [
       "default",
@@ -311,7 +328,43 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
       s.infoEl.remove();
       div.appendChild(containerEl.lastChild as Node);
     });
+  }
 
+  private addIconPickerSetting(
+    containerEl: HTMLElement,
+    name: string,
+    key: "iconReading" | "iconLive" | "iconSource",
+    defaultIcon: string
+  ) {
+    const setting = new Setting(containerEl).setName(name);
 
+    setting.addText((text) => {
+      text
+        .setPlaceholder(defaultIcon)
+        .setValue(this.plugin.settings[key])
+        .onChange(async (value) => {
+          const icon = value.trim() || defaultIcon;
+          this.plugin.settings[key] = icon;
+          previewEl.empty();
+          setIcon(previewEl, icon);
+          await this.plugin.saveSettings();
+          decorateFileExplorer(this.plugin);
+          decorateNotebookNavigator(this.plugin);
+        });
+    });
+
+    const previewEl = setting.controlEl.createSpan({ cls: "current-view-icon-preview" });
+    setIcon(previewEl, this.plugin.settings[key]);
+
+    setting.addExtraButton((btn) => {
+      btn
+        .setIcon("rotate-ccw")
+        .setTooltip("Reset to default")
+        .onClick(async () => {
+          this.plugin.settings[key] = defaultIcon;
+          await this.plugin.saveSettings();
+          this.display();
+        });
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Users can now choose their own Lucide icon for each view mode (Reading, Live Preview, Source) in the plugin settings
- The plugin now detects frontmatter view mode changes on the active note without requiring a file switch

## What changed

### Configurable view mode icons
- New settings: `iconReading`, `iconLive`, `iconSource` (defaults: `book-open`, `pen-tool`, `code`)
- New settings section **View Mode Icons** with a text input per mode, a live icon preview, and a reset-to-default button
- Extracted shared icon logic into `src/lib/icons.ts` (`getModeIcon()`), removing the duplicated `renderModeIcon()` functions in `context-menu.ts` and `notebook-navigator.ts`
- All icons are from the Lucide set built into Obsidian (no external assets); a link to lucide.dev is shown in the settings description

### Frontmatter change detection
- New setting **Frontmatter change detection** (dropdown):
  - `Off` — old behaviour, no reaction
  - `Show notification with Apply button` *(default)* — shows a Notice with an "Apply now" button
  - `Apply automatically` — applies the new view mode immediately
- Listens to `metadataCache.on('changed')` (debounced 500 ms) for the currently active file
- Uses `settings.customFrontmatterKey` for the lookup — respects whatever key the user has configured
- Only reacts when the resolved mode actually differs from the current leaf state (no false positives)

## Tests

- Added `__tests__/icons.spec.ts` with 5 tests for `getModeIcon()`
- All 27 tests pass, build is clean