### PR TITLE
fix: prevent notification flood when editing in a reading-locked folder

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ type MarkdownViewState = {
 export default class CurrentViewSettingsPlugin extends Plugin {
   settings: CurrentViewSettings;
   openedFiles: string[];
+  private activeNotice: Notice | undefined;
 
   async onload() {
     await this.loadSettings();
@@ -202,7 +203,7 @@ export default class CurrentViewSettingsPlugin extends Plugin {
 
           if (this.settings.frontmatterChangeReload === "auto") {
             void readViewModeFromFrontmatterAndToggle(leaf);
-          } else {
+          } else if (!this.activeNotice) {
             const modeLabel =
               resolvedMode === "reading"
                 ? "Reading"
@@ -214,11 +215,14 @@ export default class CurrentViewSettingsPlugin extends Plugin {
               text: `Current View: view mode changed to ${modeLabel}. `,
             });
             const btn = frag.createEl("button", { text: "Apply now" });
-            const notice = new Notice(frag, 8000);
+            this.activeNotice = new Notice(frag, 8000);
+            const clearNotice = () => { this.activeNotice = undefined; };
             btn.addEventListener("click", () => {
-              notice.hide();
+              this.activeNotice?.hide();
+              clearNotice();
               void readViewModeFromFrontmatterAndToggle(leaf);
             });
+            window.setTimeout(clearNotice, 8000);
           }
         }, 500)
       )


### PR DESCRIPTION
## Summary

- Fixes #60
- Adds an `activeNotice` instance variable to track whether a "view mode changed" notice is already visible
- Subsequent `metadataCache.changed` events (e.g. from Obsidian autosave every ~2s) are skipped while a notice is active, preventing the flood of stacked notifications
- The notice reference is cleared automatically after 8s (timeout) or immediately when the user clicks "Apply now"

## Test plan

- [x] Lock a folder to reading mode
- [x] Open a note in that folder and manually switch to Live Preview
- [x] Start typing — confirm only **one** notification appears, not one per autosave
- [x] Verify the notification disappears after ~8s and a new one can appear afterwards
- [x] Verify "Apply now" still works and switches back to reading mode