### PR TITLE
fix: defer view mode switch for Templater folder templates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
   ViewState,
   Menu,
   Notice,
+  EventRef,
 } from "obsidian";
 import { resolveViewModeDecision } from "./lib/view-mode";
 import {
@@ -28,10 +29,13 @@ type MarkdownViewState = {
   source: boolean;
 };
 
+const TEMPLATER_FALLBACK_TIMEOUT_MS = 3000;
+
 export default class CurrentViewSettingsPlugin extends Plugin {
   settings: CurrentViewSettings;
   openedFiles: string[];
   private activeNotice: Notice | undefined;
+  private recentlyCreated = new Set<string>();
 
   async onload() {
     await this.loadSettings();
@@ -41,6 +45,24 @@ export default class CurrentViewSettingsPlugin extends Plugin {
     this.addSettingTab(new CurrentViewSettingsTab(this.app, this));
 
     this.openedFiles = resetOpenedNotes(this.app);
+
+    // Track newly created markdown files so the Templater integration below can
+    // identify whether a file is being opened for the first time after creation.
+    this.registerEvent(
+      this.app.vault.on("create", (file) => {
+        if (file instanceof TFile && file.extension === "md") {
+          this.recentlyCreated.add(file.path);
+          window.setTimeout(
+            () => this.recentlyCreated.delete(file.path),
+            TEMPLATER_FALLBACK_TIMEOUT_MS + 1000
+          );
+        }
+      })
+    );
+
+    const getTemplaterPlugin = () =>
+      // @ts-ignore - Obsidian does not type the internal community plugin registry.
+      this.app.plugins?.plugins?.["templater-obsidian"] ?? null;
 
     const readViewModeFromFrontmatterAndToggle = async (leaf: WorkspaceLeaf) => {
       let view = leaf.view instanceof MarkdownView ? leaf.view : null;
@@ -59,6 +81,30 @@ export default class CurrentViewSettingsPlugin extends Plugin {
       ) {
         this.openedFiles = resetOpenedNotes(this.app);
         return;
+      }
+
+      if (view.file && this.recentlyCreated.has(view.file.path)) {
+        this.recentlyCreated.delete(view.file.path);
+        if (getTemplaterPlugin()) {
+          let ref: EventRef | undefined;
+          let timeout: number | undefined;
+          let didApply = false;
+
+          const applyDeferredViewMode = () => {
+            if (didApply) return;
+            didApply = true;
+            if (ref) this.app.workspace.offref(ref);
+            if (timeout) window.clearTimeout(timeout);
+            void readViewModeFromFrontmatterAndToggle(leaf);
+          };
+
+          ref = this.app.workspace.on(
+            "templater:all-templates-executed" as any,
+            applyDeferredViewMode
+          );
+          timeout = window.setTimeout(applyDeferredViewMode, TEMPLATER_FALLBACK_TIMEOUT_MS);
+          return;
+        }
       }
 
       const matchedRuleModes = collectMatchedRules(


### PR DESCRIPTION
## Problem

Fixes #58

When a new note is created in a folder locked to a specific view mode, Current View switches the view immediately on `active-leaf-change` — before Templater has a chance to apply its folder template. Templater then fails silently because it cannot write to a note that's in Reading mode.

## Solution

Two changes in `src/main.ts`:

**1. Track newly created files** via `vault.on("create")` — newly created `.md` files are added to a `recentlyCreated` Set with a self-cleaning timeout.

**2. Defer on `active-leaf-change`** — when a newly created file is opened and Templater is installed, the view mode switch is deferred by listening for Templater's `templater:all-templates-executed` workspace event. A 3-second fallback timeout ensures the view mode is still applied if no folder template is configured.

The Templater plugin detection follows the same pattern already used for Notebook Navigator (`src/ui/notebook-navigator.ts`).

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| New note in locked folder, Templater + folder template | ❌ Templater fails, mode locked too early | ✅ Template applies, then view mode switches |
| New note in locked folder, no Templater | ✅ Works | ✅ Works (unchanged) |
| New note in locked folder, Templater installed but no template | ✅ Works | ✅ Works (3s fallback) |
| Existing note opened in locked folder | ✅ Works | ✅ Works (unchanged) |

## Test plan

- [ ] Install Templater, configure a folder template for a folder locked to Reading mode
- [ ] Create a new note in that folder → template applies cleanly, then view switches to Reading
- [ ] Repeat without a folder template configured → view switches after ~3s
- [ ] Open an existing note in a locked folder → view switches immediately (unaffected)
- [ ] `npm run test && npm run build` passes