### PR TITLE
feat: property rules — set view mode from arbitrary frontmatter values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,14 @@ This is an Obsidian plugin that automatically sets view modes (Reading, Live Pre
 ### View Mode Priority
 
 When resolving which mode to apply (in `resolveViewModeDecision`):
-1. File pattern rules (exact path or regex match)
-2. Folder rules (deepest matching folder wins)
-3. Frontmatter value (customizable key, default `current view`)
-4. Obsidian default view mode (fallback)
+1. Frontmatter value (customizable key, default `current view`) — returns immediately
+2. File pattern rules (exact path or regex match)
+3. Tag rules (any matching tag in frontmatter)
+4. Folder rules (deepest matching folder wins)
+5. Property rules (frontmatter property matches a configured value)
+6. Obsidian default view mode (fallback)
+
+Mechanically, rules 2–5 share one list: `collectMatchedRules()` pushes property rules first, then folder, tag, and file pattern rules, and the **last** matched entry wins.
 
 ### Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This is an Obsidian plugin that automatically sets view modes (Reading, Live Pre
 - `src/main.ts` - Plugin entry point. Registers `active-leaf-change` event listener (with optional debounce), context menus for file/folder locking, and file explorer decorations. Contains the core `readViewModeFromFrontmatterAndToggle` logic.
 - `src/config/settings.ts` - Settings interface (`CurrentViewSettings`), defaults, path normalization utilities, and migration functions for legacy data.
 - `src/lib/view-mode.ts` - Pure functions for view mode resolution. `resolveViewModeDecision()` is the main decision function that takes matched rules and frontmatter, returns the final mode.
-- `src/lib/rules.ts` - Rule matching logic. `collectMatchedRules()` gathers all applicable folder/file pattern rules. `resolveFrontmatterMode()` extracts mode from note frontmatter.
+- `src/lib/rules.ts` - Rule matching logic. `collectMatchedRules()` gathers all applicable property, folder, tag, and file pattern rules (in that push order; last wins). `resolveFrontmatterMode()` extracts mode from note frontmatter.
 - `src/ui/context-menu.ts` - File explorer context menu integration and lock badge decorations.
 - `src/ui/settings-tab.ts` - Plugin settings UI.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Configure view modes based on:
 - **📁 Folder paths** – All notes in `Templates/` open in Source mode
 - **🔍 File patterns** – Match files using RegEx (e.g., all daily notes)
 - **🏷️ Tag rules** – Match notes by Obsidian tags (e.g., all notes tagged `sent` open in Reading mode)
+- **🔑 Property rules** – Match notes by the value of any frontmatter property (e.g., all notes with `status: draft` open in Live Preview)
 - **📋 Frontmatter** – Per-note control with custom metadata field
 
 <p align="center">
@@ -84,7 +85,8 @@ When you open a note, Current View checks for view mode rules in this order:
 2. File Pattern Rules  →  Exact path match or RegEx pattern
 3. Tag Rules           →  Any matching tag in frontmatter
 4. Folder Rules        →  Deepest matching folder wins
-5. Obsidian Default    →  Your global Obsidian setting
+5. Property Rules      →  Frontmatter property matches a configured value
+6. Obsidian Default    →  Your global Obsidian setting
 ```
 
 **Example:**
@@ -145,6 +147,15 @@ Mode: reading
 ```
 Any note with `tags: [sent]` in its frontmatter will automatically open in Reading mode.
 
+**🔑 Notes in a review workflow:**
+```yaml
+# Notes with acceptance-status: proposed open in Reading mode
+Property: acceptance-status
+Value: proposed
+Mode: reading
+```
+Matching is trimmed and case-insensitive; list properties match if any element matches, and booleans/numbers match their string form (e.g. value `true` matches `retired: true`). Leave the value empty to match any note where the property is present and non-empty. Property rules never write to your notes — the view mode is derived on the fly, so changing the property on an open note is picked up by the frontmatter change detection setting.
+
 ---
 
 ## ⚙️ Settings
@@ -178,6 +189,7 @@ Any note with `tags: [sent]` in its frontmatter will automatically open in Readi
 
 - **Folder Rules**: Apply view mode to all notes in a folder (context menu locks write here)
 - **Tag Rules**: Apply view mode to notes that have a specific tag
+- **Property Rules**: Apply view mode to notes where a frontmatter property has a specific value (lowest priority of all rule types)
 - **File Patterns**: RegEx patterns or exact file paths (context menu file locks write here)
 
 ---

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -1,4 +1,4 @@
-import { getFileTags, collectMatchedRules, resolveLockModeForPath } from "../src/lib/rules";
+import { getFileTags, collectMatchedRules, resolveLockModeForPath, matchPropertyRules } from "../src/lib/rules";
 import { App, TFile } from "obsidian";
 import type { CurrentViewSettings } from "../src/config/settings";
 
@@ -145,6 +145,93 @@ describe("collectMatchedRules – tag rules", () => {
     const result = collectMatchedRules(app, settings, file, () => false);
     // folder rule first, tag rule second → tag rule wins
     expect(result).toEqual([`${key}: live`, `${key}: reading`]);
+  });
+});
+
+describe("matchPropertyRules", () => {
+  const rule = (k: string, v: string) => ({ key: k, value: v, mode: `${key}: reading` });
+
+  test("matches a string value, trimmed and case-insensitive", () => {
+    expect(matchPropertyRules({ "acceptance-status": "Proposed " }, [rule("acceptance-status", "proposed")]))
+      .toEqual([`${key}: reading`]);
+  });
+
+  test("does not match a different value", () => {
+    expect(matchPropertyRules({ "acceptance-status": "accepted" }, [rule("acceptance-status", "proposed")]))
+      .toEqual([]);
+  });
+
+  test("does not match when the property is missing", () => {
+    expect(matchPropertyRules({}, [rule("acceptance-status", "proposed")])).toEqual([]);
+  });
+
+  test("matches list values when any element matches", () => {
+    expect(matchPropertyRules({ cssclasses: ["wide", "Archived"] }, [rule("cssclasses", "archived")]))
+      .toEqual([`${key}: reading`]);
+  });
+
+  test("matches booleans and numbers by string form", () => {
+    expect(matchPropertyRules({ retired: true }, [rule("retired", "true")])).toEqual([`${key}: reading`]);
+    expect(matchPropertyRules({ priority: 2 }, [rule("priority", "2")])).toEqual([`${key}: reading`]);
+  });
+
+  test("empty rule value matches any present non-empty value", () => {
+    expect(matchPropertyRules({ project: "x" }, [rule("project", "")])).toEqual([`${key}: reading`]);
+    expect(matchPropertyRules({ project: "" }, [rule("project", "")])).toEqual([]);
+    expect(matchPropertyRules({ project: null }, [rule("project", "")])).toEqual([]);
+    expect(matchPropertyRules({ project: [] }, [rule("project", "")])).toEqual([]);
+    expect(matchPropertyRules({}, [rule("project", "")])).toEqual([]);
+  });
+
+  test("skips rules with an empty key or empty mode", () => {
+    expect(matchPropertyRules({ a: "b" }, [
+      { key: "", value: "b", mode: `${key}: reading` },
+      { key: "a", value: "b", mode: "" },
+    ])).toEqual([]);
+  });
+
+  test("returns null-safe empty array without frontmatter", () => {
+    expect(matchPropertyRules(undefined, [rule("a", "b")])).toEqual([]);
+  });
+
+  test("returns multiple matches in settings order", () => {
+    expect(matchPropertyRules({ a: "1", b: "2" }, [
+      { key: "a", value: "1", mode: `${key}: reading` },
+      { key: "b", value: "2", mode: `${key}: live` },
+    ])).toEqual([`${key}: reading`, `${key}: live`]);
+  });
+});
+
+describe("collectMatchedRules – property rules", () => {
+  test("includes property-rule matches", () => {
+    const app = makeApp({ "acceptance-status": "proposed" });
+    const settings = makeSettings({
+      propertyRules: [{ key: "acceptance-status", value: "proposed", mode: `${key}: reading` }],
+    });
+    const file = new TFile("notes/a.md");
+    expect(collectMatchedRules(app, settings, file, () => false)).toEqual([`${key}: reading`]);
+  });
+
+  test("property rules are pushed first so every other rule type wins (last-wins)", () => {
+    const app = makeApp({ "acceptance-status": "proposed", tags: ["sent"] });
+    const settings = makeSettings({
+      propertyRules: [{ key: "acceptance-status", value: "proposed", mode: `${key}: reading` }],
+      folderRules: [{ path: "notes", mode: `${key}: source` }],
+      tagRules: [{ tag: "sent", mode: `${key}: live` }],
+    });
+    const file = new TFile("notes/a.md");
+    expect(collectMatchedRules(app, settings, file, () => false)).toEqual([
+      `${key}: reading`,
+      `${key}: source`,
+      `${key}: live`,
+    ]);
+  });
+
+  test("tolerates settings without propertyRules (legacy data.json)", () => {
+    const app = makeApp({ tags: ["sent"] });
+    const settings = makeSettings({ tagRules: [{ tag: "sent", mode: `${key}: reading` }] });
+    const file = new TFile("a.md");
+    expect(collectMatchedRules(app, settings, file, () => false)).toEqual([`${key}: reading`]);
   });
 });
 

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -177,10 +177,30 @@ describe("matchPropertyRules", () => {
 
   test("empty rule value matches any present non-empty value", () => {
     expect(matchPropertyRules({ project: "x" }, [rule("project", "")])).toEqual([`${key}: reading`]);
+    expect(matchPropertyRules({ project: ["x"] }, [rule("project", "")])).toEqual([`${key}: reading`]);
     expect(matchPropertyRules({ project: "" }, [rule("project", "")])).toEqual([]);
     expect(matchPropertyRules({ project: null }, [rule("project", "")])).toEqual([]);
     expect(matchPropertyRules({ project: [] }, [rule("project", "")])).toEqual([]);
+    expect(matchPropertyRules({ project: [""] }, [rule("project", "")])).toEqual([]);
+    expect(matchPropertyRules({ project: [null] }, [rule("project", "")])).toEqual([]);
     expect(matchPropertyRules({}, [rule("project", "")])).toEqual([]);
+  });
+
+  test("never resolves inherited object members as frontmatter values", () => {
+    expect(matchPropertyRules({ a: "b" }, [rule("toString", "")])).toEqual([]);
+    expect(matchPropertyRules({ a: "b" }, [rule("constructor", "")])).toEqual([]);
+    expect(matchPropertyRules({ toString: "custom" }, [rule("toString", "custom")]))
+      .toEqual([`${key}: reading`]);
+  });
+
+  test("tolerates malformed rule entries without throwing", () => {
+    const malformed = [
+      { mode: `${key}: reading` },
+      { key: 3, value: "b", mode: `${key}: reading` },
+      { key: "a", value: null, mode: `${key}: reading` },
+      { key: "a", value: "b", mode: `${key}: reading` },
+    ] as unknown as Parameters<typeof matchPropertyRules>[1];
+    expect(matchPropertyRules({ a: "b" }, malformed)).toEqual([`${key}: reading`]);
   });
 
   test("skips rules with an empty key or empty mode", () => {
@@ -249,37 +269,13 @@ describe("resolveLockModeForPath", () => {
     expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: reading`);
   });
 
-  test("falls back to property rules when nothing else matches", () => {
+  test("property rules never surface as explorer locks (Unlock cannot remove them)", () => {
     const file = new TFile("notes/a.md");
     const app = makeApp({ "acceptance-status": "proposed" });
     app.vault.getAbstractFileByPath = () => file;
     const settings = makeSettings({
       propertyRules: [{ key: "acceptance-status", value: "proposed", mode: `${key}: reading` }],
     });
-    expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: reading`);
-  });
-
-  test("property rules lose to folder rules", () => {
-    const file = new TFile("notes/a.md");
-    const app = makeApp({ "acceptance-status": "proposed" });
-    app.vault.getAbstractFileByPath = () => file;
-    const settings = makeSettings({
-      propertyRules: [{ key: "acceptance-status", value: "proposed", mode: `${key}: reading` }],
-      folderRules: [{ path: "notes", mode: `${key}: source` }],
-    });
-    expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: source`);
-  });
-
-  test("last matching property rule wins", () => {
-    const file = new TFile("a.md");
-    const app = makeApp({ a: "1", b: "2" });
-    app.vault.getAbstractFileByPath = () => file;
-    const settings = makeSettings({
-      propertyRules: [
-        { key: "a", value: "1", mode: `${key}: reading` },
-        { key: "b", value: "2", mode: `${key}: live` },
-      ],
-    });
-    expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: live`);
+    expect(resolveLockModeForPath(app, settings, file.path)).toBeNull();
   });
 });

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -248,4 +248,38 @@ describe("resolveLockModeForPath", () => {
 
     expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: reading`);
   });
+
+  test("falls back to property rules when nothing else matches", () => {
+    const file = new TFile("notes/a.md");
+    const app = makeApp({ "acceptance-status": "proposed" });
+    app.vault.getAbstractFileByPath = () => file;
+    const settings = makeSettings({
+      propertyRules: [{ key: "acceptance-status", value: "proposed", mode: `${key}: reading` }],
+    });
+    expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: reading`);
+  });
+
+  test("property rules lose to folder rules", () => {
+    const file = new TFile("notes/a.md");
+    const app = makeApp({ "acceptance-status": "proposed" });
+    app.vault.getAbstractFileByPath = () => file;
+    const settings = makeSettings({
+      propertyRules: [{ key: "acceptance-status", value: "proposed", mode: `${key}: reading` }],
+      folderRules: [{ path: "notes", mode: `${key}: source` }],
+    });
+    expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: source`);
+  });
+
+  test("last matching property rule wins", () => {
+    const file = new TFile("a.md");
+    const app = makeApp({ a: "1", b: "2" });
+    app.vault.getAbstractFileByPath = () => file;
+    const settings = makeSettings({
+      propertyRules: [
+        { key: "a", value: "1", mode: `${key}: reading` },
+        { key: "b", value: "2", mode: `${key}: live` },
+      ],
+    });
+    expect(resolveLockModeForPath(app, settings, file.path)).toBe(`${key}: live`);
+  });
 });

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -3,6 +3,7 @@ import { App, TFolder } from "obsidian";
 export type PathRule = { path: string; mode: string };
 export type PatternRule = { pattern: string; mode: string };
 export type TagRule = { tag: string; mode: string };
+export type PropertyRule = { key: string; value: string; mode: string };
 
 export interface CurrentViewSettings {
   debounceTimeout: number;
@@ -13,6 +14,7 @@ export interface CurrentViewSettings {
   explicitFileRules: PathRule[]; // legacy; migrated into filePatterns
   filePatterns: PatternRule[];
   tagRules: TagRule[];
+  propertyRules: PropertyRule[];
   showExplorerIcons: boolean;
   showLockNotifications: boolean;
   iconReading: string;
@@ -30,6 +32,7 @@ export const DEFAULT_SETTINGS: CurrentViewSettings = {
   explicitFileRules: [],
   filePatterns: [{ pattern: "", mode: "" }],
   tagRules: [{ tag: "", mode: "" }],
+  propertyRules: [{ key: "", value: "", mode: "" }],
   showExplorerIcons: true,
   showLockNotifications: true,
   iconReading: "book-open",

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -16,12 +16,11 @@ export const getFileTags = (app: App, file: TFile | null): string[] => {
 export type ViewLockMode = "reading" | "source" | "live";
 
 const propertyValueMatches = (fmValue: unknown, ruleValue: string): boolean => {
-  const normalizedRuleValue = ruleValue.trim().toLowerCase();
   if (Array.isArray(fmValue)) {
-    if (normalizedRuleValue === "") return fmValue.length > 0;
     return fmValue.some((element) => propertyValueMatches(element, ruleValue));
   }
   if (fmValue === null || fmValue === undefined) return false;
+  const normalizedRuleValue = ruleValue.trim().toLowerCase();
   const normalizedFmValue = String(fmValue).trim().toLowerCase();
   if (normalizedRuleValue === "") return normalizedFmValue !== "";
   return normalizedFmValue === normalizedRuleValue;
@@ -33,9 +32,14 @@ export const matchPropertyRules = (
 ): string[] => {
   if (!frontmatter) return [];
   const matched: string[] = [];
-  for (const { key, value, mode } of propertyRules) {
-    if (!key.trim() || !mode) continue;
-    if (propertyValueMatches(frontmatter[key.trim()], value)) {
+  for (const rule of propertyRules) {
+    // Tolerate malformed data.json entries — this runs on every leaf/metadata event
+    const key = typeof rule.key === "string" ? rule.key.trim() : "";
+    const mode = typeof rule.mode === "string" ? rule.mode : "";
+    if (!key || !mode || typeof rule.value !== "string") continue;
+    // Own-property check so keys like "toString" never hit the prototype chain
+    if (!Object.prototype.hasOwnProperty.call(frontmatter, key)) continue;
+    if (propertyValueMatches(frontmatter[key], rule.value)) {
       matched.push(mode);
     }
   }
@@ -136,14 +140,11 @@ export const resolveLockModeForPath = (
     .pop();
   if (folderRule) return folderRule.mode;
 
-  if (file instanceof TFile) {
-    const fileCache = app.metadataCache.getFileCache(file);
-    const propertyMatches = matchPropertyRules(
-      fileCache?.frontmatter,
-      settings.propertyRules ?? []
-    );
-    if (propertyMatches.length) return propertyMatches[propertyMatches.length - 1];
-  }
+  // Property rules are deliberately NOT consulted here: this resolver feeds the
+  // explorer lock badges and the Lock/Unlock context menu, and Unlock cannot
+  // remove a vault-wide property rule — surfacing them would create
+  // "locks" that falsely claim to unlock. They only affect view-mode
+  // application via collectMatchedRules.
 
   return null;
 };

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -1,5 +1,5 @@
 import { normalizeFrontmatterMode } from "./view-mode";
-import type { CurrentViewSettings } from "../config/settings";
+import type { CurrentViewSettings, PropertyRule } from "../config/settings";
 import { normalizePath, isPathWithin } from "../config/settings";
 import { TFile, App } from "obsidian";
 
@@ -15,6 +15,33 @@ export const getFileTags = (app: App, file: TFile | null): string[] => {
 
 export type ViewLockMode = "reading" | "source" | "live";
 
+const propertyValueMatches = (fmValue: unknown, ruleValue: string): boolean => {
+  const normalizedRuleValue = ruleValue.trim().toLowerCase();
+  if (Array.isArray(fmValue)) {
+    if (normalizedRuleValue === "") return fmValue.length > 0;
+    return fmValue.some((element) => propertyValueMatches(element, ruleValue));
+  }
+  if (fmValue === null || fmValue === undefined) return false;
+  const normalizedFmValue = String(fmValue).trim().toLowerCase();
+  if (normalizedRuleValue === "") return normalizedFmValue !== "";
+  return normalizedFmValue === normalizedRuleValue;
+};
+
+export const matchPropertyRules = (
+  frontmatter: Record<string, unknown> | null | undefined,
+  propertyRules: PropertyRule[]
+): string[] => {
+  if (!frontmatter) return [];
+  const matched: string[] = [];
+  for (const { key, value, mode } of propertyRules) {
+    if (!key.trim() || !mode) continue;
+    if (propertyValueMatches(frontmatter[key.trim()], value)) {
+      matched.push(mode);
+    }
+  }
+  return matched;
+};
+
 export const collectMatchedRules = (
   app: App,
   settings: CurrentViewSettings,
@@ -22,6 +49,12 @@ export const collectMatchedRules = (
   filenameMatch: (pattern: string) => boolean
 ): string[] => {
   const matchedRuleModes: string[] = [];
+
+  // Property rules (lowest priority — every later rule type overrides via last-wins)
+  const fileCache = file ? app.metadataCache.getFileCache(file) : null;
+  matchedRuleModes.push(
+    ...matchPropertyRules(fileCache?.frontmatter, settings.propertyRules ?? [])
+  );
 
   // Folder rules (deepest wins because later entries override earlier ones)
   const matchedFolders = settings.folderRules

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -136,5 +136,14 @@ export const resolveLockModeForPath = (
     .pop();
   if (folderRule) return folderRule.mode;
 
+  if (file instanceof TFile) {
+    const fileCache = app.metadataCache.getFileCache(file);
+    const propertyMatches = matchPropertyRules(
+      fileCache?.frontmatter,
+      settings.propertyRules ?? []
+    );
+    if (propertyMatches.length) return propertyMatches[propertyMatches.length - 1];
+  }
+
   return null;
 };

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -276,6 +276,74 @@ export class CurrentViewSettingsTab extends PluginSettingTab {
       div.appendChild(containerEl.lastChild as Node);
     });
 
+    // === Property Rules ===
+    new Setting(containerEl).setName("Property rules").setHeading();
+
+    new Setting(containerEl)
+      .setDesc(
+        "Apply view mode to notes where a frontmatter property has a specific value (e.g. key \"acceptance-status\", value \"proposed\"). Leave the value empty to match any note where the property is present and non-empty. Property rules have the lowest priority: folder rules, tag rules, file patterns, and the frontmatter key all override them."
+      );
+
+    new Setting(containerEl)
+      .setName("Add property rule")
+      .setDesc("Click to add a new property rule")
+      .addButton((button) => {
+        button
+          .setTooltip("Add property rule")
+          .setButtonText("+")
+          .setCta()
+          .onClick(async () => {
+            this.plugin.settings.propertyRules.push({ key: "", value: "", mode: "" });
+            await this.plugin.saveSettings();
+            this.display();
+          });
+      });
+
+    this.plugin.settings.propertyRules.forEach((rule, index) => {
+      const div = containerEl.createDiv();
+      div.addClass("force-view-mode-div");
+      div.addClass("force-view-mode-folder");
+
+      const s = new Setting(this.containerEl)
+        .addText((cb) => {
+          cb.setPlaceholder("Property (e.g. acceptance-status)")
+            .setValue(rule.key)
+            .onChange(async (value) => {
+              this.plugin.settings.propertyRules[index].key = value;
+              await this.plugin.saveSettings();
+            });
+        })
+        .addText((cb) => {
+          cb.setPlaceholder("Value (e.g. proposed)")
+            .setValue(rule.value)
+            .onChange(async (value) => {
+              this.plugin.settings.propertyRules[index].value = value;
+              await this.plugin.saveSettings();
+            });
+        })
+        .addDropdown((cb) => {
+          modes.forEach((mode) => {
+            cb.addOption(mode, mode);
+          });
+          cb.setValue(rule.mode || "default").onChange(async (value) => {
+            this.plugin.settings.propertyRules[index].mode = value;
+            await this.plugin.saveSettings();
+          });
+        })
+        .addExtraButton((cb) => {
+          cb.setIcon("cross")
+            .setTooltip("Delete")
+            .onClick(async () => {
+              this.plugin.settings.propertyRules.splice(index, 1);
+              await this.plugin.saveSettings();
+              this.display();
+            });
+        });
+
+      s.infoEl.remove();
+      div.appendChild(containerEl.lastChild as Node);
+    });
+
     // === File Pattern Rules ===
     new Setting(containerEl).setName("File pattern rules").setHeading();
     


### PR DESCRIPTION
## What

Adds a fourth rule type, **property rules**: `{key, value, mode}` entries that set a note's view mode when an arbitrary frontmatter property matches a value — e.g. open every note with `status: draft` in Live Preview, or `acceptance-status: proposed` in Reading mode, without writing anything into the note.

## Why

Folder, tag, and pattern rules cover *where* a note lives and *how it's tagged*, but a lot of vault state lives in frontmatter properties (workflow status, review state, publish flags). Today the only way to map those to a view mode is materializing the `current view` key into every note. Property rules derive the mode instead, so nothing is written and the mode follows the property automatically (the existing frontmatter change detection picks up edits to watched properties, since the metadata-change handler re-runs `collectMatchedRules`).

## Semantics

- Trim + case-insensitive matching; list properties match if any element matches; booleans/numbers match their string form (`true` matches `retired: true`); empty value = "property present and non-empty".
- Own-property lookups only (keys like `toString` can't match prototype members) and malformed `data.json` entries are skipped, not thrown on — this path runs on every leaf/metadata event.
- **Lowest priority of all rule types**: frontmatter key > file patterns > tag rules > folder rules > property rules > default. Implemented by pushing property matches first in `collectMatchedRules` (last-wins).
- Deliberately **not** surfaced through `resolveLockModeForPath`: that resolver feeds the explorer lock badges and the Lock/Unlock context menu, and Unlock can't remove a vault-wide property rule — surfacing them would create locks that falsely claim to unlock. Happy to wire badges in a follow-up if you'd prefer them visible.
- Existing `data.json` without `propertyRules` keeps working (defaulted on load, `?? []` guards).

## Changes

- `src/config/settings.ts` — `PropertyRule` type, `propertyRules` setting + default
- `src/lib/rules.ts` — pure `matchPropertyRules()` + wiring into `collectMatchedRules`
- `src/ui/settings-tab.ts` — "Property rules" settings section (mirrors the tag-rules section)
- `README.md` / `CLAUDE.md` — docs, including a fix to the stale priority list (frontmatter actually resolves first in `resolveViewModeDecision`)
- `__tests__/rules.spec.ts` — 15 new tests covering matching semantics, precedence, and malformed-config tolerance

`npm run test` (42 passing) and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)